### PR TITLE
Update Par.cpp

### DIFF
--- a/src/Par.cpp
+++ b/src/Par.cpp
@@ -7,7 +7,7 @@
    See LICENSE and README.
 */
 
-
+#include <cstdio>
 #include <stdexcept>
 #include <algorithm>
 #include <string.h>


### PR DESCRIPTION
Add include needed for sprintf.

Causes a compilation error in OpenSpiel: https://github.com/deepmind/open_spiel/issues/407#issuecomment-719131843